### PR TITLE
fix: Add null check

### DIFF
--- a/src/main/java/re/imc/geysermodelengine/model/EntityTask.java
+++ b/src/main/java/re/imc/geysermodelengine/model/EntityTask.java
@@ -235,10 +235,15 @@ public class EntityTask {
         Entity entity = model.getEntity();
 
         Map<String, Boolean> updates = new HashMap<>();
-        model.getActiveModel().getBones().forEach((s,bone) -> {
-            if (!lastModelBoneSet.containsKey(bone)) lastModelBoneSet.put(bone, !bone.isVisible());
+        model.getActiveModel().getBones().forEach((s, bone) -> {
+            if (!lastModelBoneSet.containsKey(bone))
+                lastModelBoneSet.put(bone, !bone.isVisible());
 
-            if (!lastModelBoneSet.get(bone).equals(bone.isVisible()) || ignore) {
+            Boolean lastBone = lastModelBoneSet.get(bone);
+            if (lastBone == null)
+                return;
+
+            if (!lastBone.equals(bone.isVisible()) || ignore) {
                 String name = unstripName(bone).toLowerCase();
                 updates.put(model.getActiveModel().getBlueprint().getName() + ":" + name, bone.isVisible());
                 lastModelBoneSet.replace(bone, bone.isVisible());


### PR DESCRIPTION
```
[13:30:57 WARN]: [GeyserModelEngine] Plugin GeyserModelEngine v1.0-SNAPSHOT generated an exception while executing task 2392
java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.equals(Object)" because the return value of "java.util.Map.get(Object)" is null
        at re.imc.geysermodelengine.model.EntityTask.lambda$updateEntityProperties$4(EntityTask.java:241) ~[GeyserModelEngine-1.0-SNAPSHOT.jar:?]
        at com.google.common.collect.RegularImmutableMap.forEach(RegularImmutableMap.java:297) ~[guava-32.1.2-jre.jar:?]
        at re.imc.geysermodelengine.model.EntityTask.updateEntityProperties(EntityTask.java:238) ~[GeyserModelEngine-1.0-SNAPSHOT.jar:?]
        at re.imc.geysermodelengine.model.EntityTask.lambda$runAsync$0(EntityTask.java:163) ~[GeyserModelEngine-1.0-SNAPSHOT.jar:?]
        at java.util.concurrent.ConcurrentHashMap$KeySetView.forEach(ConcurrentHashMap.java:4709) ~[?:?]
        at re.imc.geysermodelengine.model.EntityTask.runAsync(EntityTask.java:163) ~[GeyserModelEngine-1.0-SNAPSHOT.jar:?]
        at re.imc.geysermodelengine.model.EntityTask$3.run(EntityTask.java:417) ~[GeyserModelEngine-1.0-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.v1_20_R3.scheduler.CraftTask.run(CraftTask.java:101) ~[lucille-1.20.4.jar:git-Paper-"21f57d9"]
        at org.bukkit.craftbukkit.v1_20_R3.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57) ~[lucille-1.20.4.jar:git-Paper-"21f57d9"]
        at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22) ~[lucille-1.20.4.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.lang.Thread.run(Thread.java:1583) ~[?:?]
```