### PR TITLE
fix: Entity scale not being updated

### DIFF
--- a/src/main/java/re/imc/geysermodelengine/model/EntityTask.java
+++ b/src/main/java/re/imc/geysermodelengine/model/EntityTask.java
@@ -206,11 +206,11 @@ public class EntityTask {
 
         Vector3f scale = model.getActiveModel().getScale();
         float average = (scale.x + scale.y + scale.z) / 3;
-        if (ignore) {
-            if (average == lastScale) return;
-        }
+        if (average == lastScale) return;
+
         EntityUtils.sendCustomScale(player, model.getEntity().getEntityId(), average);
 
+        if (ignore) return;
         lastScale = average;
     }
 


### PR DESCRIPTION
The scale of entities was only being updated when manually updating the sizing while already in the server, rejoining would reset the entity scale