### PR TITLE
do not reference render controllers for unbound textures

### DIFF
--- a/geyser/src/main/java/re/imc/geysermodelengineextension/managers/resourcepack/generator/Entity.java
+++ b/geyser/src/main/java/re/imc/geysermodelengineextension/managers/resourcepack/generator/Entity.java
@@ -80,8 +80,11 @@ public class Entity {
             jsonTextures.addProperty("default", "textures/entity/" + modelId);
         }
 
+        boolean singleTexture = textureMap.size() == 1 && modelConfig.getPerTextureUvSize().isEmpty();
+
         for (String name : textureMap.keySet()) {
             if (name.endsWith("_e")) continue;
+            if (modelConfig.getBingingBones().get(name) == null && !singleTexture) continue;
 
             if (modelConfig.getPerTextureUvSize().containsKey(name)) {
                 Integer[] size = modelConfig.getPerTextureUvSize().getOrDefault(name, new Integer[]{16, 16});


### PR DESCRIPTION
stop referencing render controllers for textures with no binding bones, so unbound textures (e.g. unused anim overlays) no longer cause `Invalid render controller`.

`[Geometry][error]-modelengine:MODEL | modelengine:MODEL | Invalid render controller: controller.render.MODEL_PART`