### PR TITLE
fix look_at_target reference for headless models

### DIFF
--- a/geyser/build.gradle.kts
+++ b/geyser/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "re.imc"
-version = "1.0.3"
+version = "1.0.4"
 
 repositories {
     mavenCentral()

--- a/geyser/src/main/java/re/imc/geysermodelengineextension/managers/resourcepack/generator/Entity.java
+++ b/geyser/src/main/java/re/imc/geysermodelengineextension/managers/resourcepack/generator/Entity.java
@@ -66,7 +66,7 @@ public class Entity {
                 .replace("%entity_id%", modelId)
                 .replace("%geometry%", geometryId)
                 .replace("%texture%", defaultTexturePath)
-                .replace("%look_at_target%", modelConfig.isEnableHeadRotation() ? "animation." + modelId + ".look_at_target" : "animation.none")
+                .replace("%look_at_target%", (modelConfig.isEnableHeadRotation() && hasHeadAnimation) ? "animation." + modelId + ".look_at_target" : "animation.common.look_at_target")
                 .replace("%material%", modelConfig.getMaterial())).getAsJsonObject();
 
         JsonObject description = json.get("minecraft:client_entity").getAsJsonObject().get("description").getAsJsonObject();


### PR DESCRIPTION
Fix look_at_target for headless models (fall back to vanilla animation)