### PR TITLE
Feat: optional catmullrom to linear baking

### DIFF
--- a/geyser/build.gradle.kts
+++ b/geyser/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "re.imc"
-version = "1.0.4"
+version = "1.0.5"
 
 repositories {
     mavenCentral()

--- a/geyser/src/main/java/re/imc/geysermodelengineextension/managers/resourcepack/generator/Animation.java
+++ b/geyser/src/main/java/re/imc/geysermodelengineextension/managers/resourcepack/generator/Animation.java
@@ -6,7 +6,10 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import re.imc.geysermodelengineextension.GeyserModelEngineExtension;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -30,6 +33,9 @@ public class Animation {
     public void load(String string) {
         this.json = JsonParser.parseString(string).getAsJsonObject();
         JsonObject newAnimations = new JsonObject();
+
+        boolean bakeCatmullrom = GeyserModelEngineExtension.getExtension().getConfigManager()
+                .getConfig().getBoolean("options.resource-pack.bake-catmullrom-to-linear", false);
 
         for (Map.Entry<String, JsonElement> element : json.get("animations").getAsJsonObject().entrySet()) {
             animationIds.add(element.getKey());
@@ -80,10 +86,268 @@ public class Animation {
                 }
             }
 
+            if (bakeCatmullrom) {
+                bakeCatmullromToLinear(animation);
+            }
+
             newAnimations.add("animation." + modelId + "." + element.getKey().replace(" ", "_"), element.getValue());
         }
 
         json.add("animations", newAnimations);
+    }
+
+    private void bakeCatmullromToLinear(JsonObject animation) {
+        if (!animation.has("bones")) return;
+
+        boolean isLooping = false;
+        if (animation.has("loop")) {
+            JsonElement loopElem = animation.get("loop");
+            if (loopElem.isJsonPrimitive() && loopElem.getAsJsonPrimitive().isBoolean()) {
+                isLooping = loopElem.getAsBoolean();
+            }
+        }
+
+        double maxTime = 0;
+        if (animation.has("animation_length")) {
+            maxTime = animation.get("animation_length").getAsDouble();
+        }
+
+        JsonObject bones = animation.get("bones").getAsJsonObject();
+        for (Map.Entry<String, JsonElement> boneEntry : bones.entrySet()) {
+            if (!boneEntry.getValue().isJsonObject()) continue;
+            JsonObject bone = boneEntry.getValue().getAsJsonObject();
+
+            for (String channelName : new String[]{"position", "rotation", "scale"}) {
+                if (!bone.has(channelName)) continue;
+                JsonElement channelElem = bone.get(channelName);
+                if (!channelElem.isJsonObject()) continue;
+
+                JsonObject channel = channelElem.getAsJsonObject();
+                if (!hasCatmullromKeyframes(channel)) continue;
+
+                List<double[]> keyframes = extractKeyframes(channel);
+                if (keyframes == null) continue;
+
+                if (keyframes.size() < 2) {
+                    stripCatmullrom(channel);
+                    continue;
+                }
+
+                double channelMaxTime = maxTime;
+                if (channelMaxTime <= 0) {
+                    channelMaxTime = keyframes.get(keyframes.size() - 1)[0];
+                }
+                if (channelMaxTime <= 0) continue;
+
+                bone.add(channelName, bakeChannel(keyframes, channelMaxTime, isLooping));
+            }
+        }
+    }
+
+    private void stripCatmullrom(JsonObject channel) {
+        for (Map.Entry<String, JsonElement> entry : channel.entrySet()) {
+            if (entry.getValue().isJsonObject()) {
+                JsonObject kf = entry.getValue().getAsJsonObject();
+                if (kf.has("lerp_mode") && "catmullrom".equals(kf.get("lerp_mode").getAsString())) {
+                    double[] values = extractValues(kf);
+                    if (values != null) {
+                        JsonArray arr = new JsonArray();
+                        arr.add(values[0]);
+                        arr.add(values[1]);
+                        arr.add(values[2]);
+                        channel.add(entry.getKey(), arr);
+                    } else {
+                        kf.remove("lerp_mode");
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean hasCatmullromKeyframes(JsonObject channel) {
+        for (Map.Entry<String, JsonElement> entry : channel.entrySet()) {
+            if (entry.getValue().isJsonObject()) {
+                JsonObject kf = entry.getValue().getAsJsonObject();
+                if (kf.has("lerp_mode") && "catmullrom".equals(kf.get("lerp_mode").getAsString())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private List<double[]> extractKeyframes(JsonObject channel) {
+        List<double[]> keyframes = new ArrayList<>();
+        for (Map.Entry<String, JsonElement> entry : channel.entrySet()) {
+            double time;
+            try {
+                time = Double.parseDouble(entry.getKey());
+            } catch (NumberFormatException e) {
+                return null;
+            }
+
+            double[] values = extractValues(entry.getValue());
+            if (values == null) return null;
+
+            keyframes.add(new double[]{time, values[0], values[1], values[2]});
+        }
+        keyframes.sort(Comparator.comparingDouble(a -> a[0]));
+        return keyframes;
+    }
+
+    private double[] extractValues(JsonElement elem) {
+        if (elem.isJsonArray()) {
+            return jsonArrayToDoubles(elem.getAsJsonArray());
+        }
+        if (elem.isJsonObject()) {
+            JsonObject obj = elem.getAsJsonObject();
+            if (obj.has("post")) {
+                return extractValues(obj.get("post"));
+            }
+            if (obj.has("vector")) {
+                return extractValues(obj.get("vector"));
+            }
+        }
+        if (elem.isJsonPrimitive()) {
+            if (elem.getAsJsonPrimitive().isNumber()) {
+                double v = elem.getAsDouble();
+                return new double[]{v, v, v};
+            }
+            return null;
+        }
+        return null;
+    }
+
+    private double[] jsonArrayToDoubles(JsonArray arr) {
+        if (arr.size() < 3) return null;
+        double[] result = new double[3];
+        for (int i = 0; i < 3; i++) {
+            JsonElement e = arr.get(i);
+            if (!e.isJsonPrimitive() || !e.getAsJsonPrimitive().isNumber()) {
+                return null;
+            }
+            result[i] = e.getAsDouble();
+        }
+        return result;
+    }
+
+    private JsonObject bakeChannel(List<double[]> keyframes, double maxTime, boolean isLooping) {
+        double step = 0.05;
+
+        double firstTime = keyframes.get(0)[0];
+        double lastTime = keyframes.get(keyframes.size() - 1)[0];
+
+        boolean shouldWrap = isLooping && firstTime < 0.01 && Math.abs(lastTime - maxTime) < 0.01;
+
+        List<double[]> samples = new ArrayList<>();
+        for (double t = 0; t <= maxTime + 0.001; t += step) {
+            double time = Math.min(t, maxTime);
+            double[] interpolated;
+
+            if (time <= firstTime) {
+                interpolated = new double[]{keyframes.get(0)[1], keyframes.get(0)[2], keyframes.get(0)[3]};
+            } else if (time >= lastTime) {
+                interpolated = new double[]{keyframes.get(keyframes.size() - 1)[1], keyframes.get(keyframes.size() - 1)[2], keyframes.get(keyframes.size() - 1)[3]};
+            } else {
+                int p1Idx = 0;
+                for (int i = 0; i < keyframes.size(); i++) {
+                    if (keyframes.get(i)[0] <= time) {
+                        p1Idx = i;
+                    }
+                }
+                int p2Idx = p1Idx + 1;
+
+                double segStart = keyframes.get(p1Idx)[0];
+                double segEnd = keyframes.get(p2Idx)[0];
+                double segLen = segEnd - segStart;
+                double localT = segLen > 0 ? (time - segStart) / segLen : 0;
+
+                double[] p0, p1, p2, p3;
+                p1 = new double[]{keyframes.get(p1Idx)[1], keyframes.get(p1Idx)[2], keyframes.get(p1Idx)[3]};
+                p2 = new double[]{keyframes.get(p2Idx)[1], keyframes.get(p2Idx)[2], keyframes.get(p2Idx)[3]};
+
+                if (p1Idx > 0) {
+                    p0 = new double[]{keyframes.get(p1Idx - 1)[1], keyframes.get(p1Idx - 1)[2], keyframes.get(p1Idx - 1)[3]};
+                } else if (shouldWrap) {
+                    int lastIdx = keyframes.size() - 1;
+                    p0 = new double[]{keyframes.get(lastIdx)[1], keyframes.get(lastIdx)[2], keyframes.get(lastIdx)[3]};
+                } else {
+                    p0 = p1.clone();
+                }
+
+                if (p2Idx < keyframes.size() - 1) {
+                    p3 = new double[]{keyframes.get(p2Idx + 1)[1], keyframes.get(p2Idx + 1)[2], keyframes.get(p2Idx + 1)[3]};
+                } else if (shouldWrap) {
+                    p3 = new double[]{keyframes.get(0)[1], keyframes.get(0)[2], keyframes.get(0)[3]};
+                } else {
+                    p3 = p2.clone();
+                }
+
+                interpolated = catmullromInterpolate(p0, p1, p2, p3, localT);
+            }
+
+            samples.add(new double[]{
+                Math.round(time * 10000.0) / 10000.0,
+                Math.round(interpolated[0] * 10000.0) / 10000.0,
+                Math.round(interpolated[1] * 10000.0) / 10000.0,
+                Math.round(interpolated[2] * 10000.0) / 10000.0
+            });
+        }
+
+        double tolerance = 0.05;
+        List<double[]> reduced = new ArrayList<>();
+        reduced.add(samples.get(0));
+
+        for (int i = 1; i < samples.size() - 1; i++) {
+            double[] prev = reduced.get(reduced.size() - 1);
+            double[] curr = samples.get(i);
+            double[] next = samples.get(i + 1);
+
+            double dt = next[0] - prev[0];
+            if (dt <= 0) continue;
+            double ratio = (curr[0] - prev[0]) / dt;
+
+            boolean needed = false;
+            for (int c = 1; c <= 3; c++) {
+                double linear = prev[c] + (next[c] - prev[c]) * ratio;
+                if (Math.abs(linear - curr[c]) > tolerance) {
+                    needed = true;
+                    break;
+                }
+            }
+            if (needed) {
+                reduced.add(curr);
+            }
+        }
+
+        reduced.add(samples.get(samples.size() - 1));
+
+        JsonObject result = new JsonObject();
+        for (double[] s : reduced) {
+            String timeKey = String.format("%.4f", s[0]).replaceAll("0+$", "").replaceAll("\\.$", "");
+            JsonArray values = new JsonArray();
+            values.add(s[1]);
+            values.add(s[2]);
+            values.add(s[3]);
+            result.add(timeKey, values);
+        }
+
+        return result;
+    }
+
+    private double[] catmullromInterpolate(double[] p0, double[] p1, double[] p2, double[] p3, double t) {
+        double t2 = t * t;
+        double t3 = t2 * t;
+        double[] result = new double[3];
+        for (int i = 0; i < 3; i++) {
+            result[i] = 0.5 * (
+                (2 * p1[i]) +
+                (-p0[i] + p2[i]) * t +
+                (2 * p0[i] - 5 * p1[i] + 4 * p2[i] - p3[i]) * t2 +
+                (-p0[i] + 3 * p1[i] - 3 * p2[i] + p3[i]) * t3
+            );
+        }
+        return result;
     }
 
     public void addHeadBind(Geometry geometry) {

--- a/geyser/src/main/java/re/imc/geysermodelengineextension/managers/resourcepack/generator/Animation.java
+++ b/geyser/src/main/java/re/imc/geysermodelengineextension/managers/resourcepack/generator/Animation.java
@@ -36,6 +36,9 @@ public class Animation {
 
         boolean bakeCatmullrom = GeyserModelEngineExtension.getExtension().getConfigManager()
                 .getConfig().getBoolean("options.resource-pack.bake-catmullrom-to-linear", false);
+        double sampleStep = GeyserModelEngineExtension.getExtension().getConfigManager()
+                .getConfig().getDouble("options.resource-pack.catmullrom-sample-step");
+        if (sampleStep <= 0) sampleStep = 0.05;
 
         for (Map.Entry<String, JsonElement> element : json.get("animations").getAsJsonObject().entrySet()) {
             animationIds.add(element.getKey());
@@ -87,7 +90,7 @@ public class Animation {
             }
 
             if (bakeCatmullrom) {
-                bakeCatmullromToLinear(animation);
+                bakeCatmullromToLinear(animation, sampleStep);
             }
 
             newAnimations.add("animation." + modelId + "." + element.getKey().replace(" ", "_"), element.getValue());
@@ -96,7 +99,7 @@ public class Animation {
         json.add("animations", newAnimations);
     }
 
-    private void bakeCatmullromToLinear(JsonObject animation) {
+    private void bakeCatmullromToLinear(JsonObject animation, double step) {
         if (!animation.has("bones")) return;
 
         boolean isLooping = false;
@@ -139,7 +142,7 @@ public class Animation {
                 }
                 if (channelMaxTime <= 0) continue;
 
-                bone.add(channelName, bakeChannel(keyframes, channelMaxTime, isLooping));
+                bone.add(channelName, bakeChannel(keyframes, channelMaxTime, isLooping, step));
             }
         }
     }
@@ -231,9 +234,7 @@ public class Animation {
         return result;
     }
 
-    private JsonObject bakeChannel(List<double[]> keyframes, double maxTime, boolean isLooping) {
-        double step = 0.05;
-
+    private JsonObject bakeChannel(List<double[]> keyframes, double maxTime, boolean isLooping, double step) {
         double firstTime = keyframes.get(0)[0];
         double lastTime = keyframes.get(keyframes.size() - 1)[0];
 

--- a/geyser/src/main/resources/Extension/config.yml
+++ b/geyser/src/main/resources/Extension/config.yml
@@ -7,3 +7,4 @@ options:
   resource-pack:
     auto-load: true
     hash-models-textures: true
+    bake-catmullrom-to-linear: false

--- a/geyser/src/main/resources/Extension/config.yml
+++ b/geyser/src/main/resources/Extension/config.yml
@@ -8,3 +8,4 @@ options:
     auto-load: true
     hash-models-textures: true
     bake-catmullrom-to-linear: false
+    catmullrom-sample-step: 0.05


### PR DESCRIPTION
Adds `options.resource-pack.bake-catmullrom-to-linear` (default `false`): bakes catmullrom animation curves into densely-sampled linear keyframes, working around a Bedrock bug where catmullrom `lerp_mode` makes models flicker/disappear during playback. Sampling density is tunable via `catmullrom-sample-step` (seconds, default `0.05`).

**Known limitation (not addressed here):** effect bones that are hidden at rest (scale 0) can still briefly flash full-size the first time an entity renders, the animation controller blends in from the model's identity pose over `blend_transition` before the property syncs. Minor; left as-is.
